### PR TITLE
修复奇怪情况下因WishSummary.WeaponStatistics为空导致的未将对象引用设置到对象的实例异常

### DIFF
--- a/src/KeqingNiuza/ViewModel/WishSummaryViewModel.cs
+++ b/src/KeqingNiuza/ViewModel/WishSummaryViewModel.cs
@@ -24,14 +24,24 @@ namespace KeqingNiuza.ViewModel
             WishSummary = WishSummary.Create(WishDataList, IgnoreFirstStar5Character, IgnoreFirstStar5Weapon, IgnoreFirstStar5Permanent);
             CharacterOrder("星级");
             WeaponOrder("星级");
-            if (!IsCorrectOrder)
-            {
-                WishSummary.CharacterStatistics.Star5List.Reverse();
-                WishSummary.CharacterStatistics.Star4List.Reverse();
-                WishSummary.WeaponStatistics.Star5List.Reverse();
-                WishSummary.WeaponStatistics.Star4List.Reverse();
-                WishSummary.PermanentStatistics.Star5List.Reverse();
-                WishSummary.PermanentStatistics.Star4List.Reverse();
+            if (!IsCorrectOrder) {
+                if (WishSummary.CharacterStatistics != null)
+                {
+                    WishSummary.CharacterStatistics.Star5List.Reverse();
+                    WishSummary.CharacterStatistics.Star4List.Reverse();
+                }
+
+                if (WishSummary.WeaponStatistics != null)
+                {
+                    WishSummary.WeaponStatistics.Star5List.Reverse();
+                    WishSummary.WeaponStatistics.Star4List.Reverse();
+                }
+
+                if (WishSummary.PermanentStatistics != null)
+                {
+                    WishSummary.PermanentStatistics.Star5List.Reverse();
+                    WishSummary.PermanentStatistics.Star4List.Reverse();
+                }
             }
         }
 


### PR DESCRIPTION
Closes #35

修复KeqingNiuza\ViewModel\WishSummaryViewModel.cs:行号 26报未将对象引用设置到对象的实例问题
简单粗暴的加了判Null
---
同样的UserData复制到项目下一切正常，而把项目编译出的Debug或Release文件复制到App目录则不正常
删除bin下全部文件，用Launcher更新，问题依旧
